### PR TITLE
Use exact hostname from api page list

### DIFF
--- a/phila_site_scraper.py
+++ b/phila_site_scraper.py
@@ -332,9 +332,7 @@ def main(save_s3, invalidate_cloudfront, logging_config, num_worker_threads, not
             for page in page_data:
                 # Often just the most recent page is returned, we don't want to just keep scraping it
                 updated_at = page['updated_at']
-                url = re.sub('https?://' + SCRAPER_HOSTNAMES_TO_FIND,
-                             'https://' + SCRAPER_HOST_FOR_URLS_AND_PAGES,
-                             page["link"])
+                url = page['link']
                 if updated_at == max_datetime and url == max_url:
                     continue
                 if updated_at > max_datetime:


### PR DESCRIPTION
The API now (in a few mins) uses whatever hostname the request was made to (in this case the ELB)
so there's no need to find/replace it with the ELB hostname.

I think the scraper should actually start working without this because a find/replace that doesn't match will just use the original string (which is the ELB url), so we can verify this once @karissademi pushes the change to WP before deploying this.