### PR TITLE
Use slack-logger library to log to slack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["python", "./phila_site_scraper.py", "--notifications", "--save-s3", "--invalidate-cloudfront", "--publish-stats", "--heartbeat"]
+CMD ["python", "./phila_site_scraper.py", "--save-s3", "--invalidate-cloudfront", "--publish-stats", "--heartbeat"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ python-dateutil==2.7.2
 requests==2.18.4
 s3transfer==0.1.13
 six==1.11.0
+slack-logger==0.3.1
 urllib3==1.22


### PR DESCRIPTION
This uses the [slack-logger](https://github.com/junhwi/python-slack-logger) library to let us post to slack with a flag on the log command. The advantage is that it includes the full stack trace and a wee bit of formatting.