### PR TITLE
Don't follow redirects

### DIFF
--- a/phila_site_scraper.py
+++ b/phila_site_scraper.py
@@ -70,7 +70,7 @@ def save_page(logger,
               s3_client,
               cloudfront_client):
     logger.info('Scraping: {}'.format(url))
-    response = session.get(url, headers=HEADER, verify=False)
+    response = session.get(url, headers=HEADER, verify=False, allow_redirects=False)
 
     key = urlparse(url).path[1:]
     if key == '':


### PR DESCRIPTION
Prior to this, the scraper was following WP-generated 301 redirects such as /programs/rebuild/ over
to rebuild.phila.gov and scraping the redirected-to external site. The only caveat here is that if
the pages endpoint included a URL like  (instead of ) the scraper would
not follow it to the correct URL and would scrape an empty document.

Note this is untested so we'll want to see this in staging first just in case there are any unexpected side-effects.